### PR TITLE
make image smaller, make -version option work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CMD_DIR = ./cmd
 CONFIG_DIR = ./config/
 
 # Get version constant
-VERSION := 1.4.1
+VERSION := ${shell git describe --abbrev=0 --tags}
 BUILD := $(shell git rev-parse HEAD)
 
 # Use linker flags to provide version/build settings to the binary

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CMD_DIR = ./cmd
 CONFIG_DIR = ./config/
 
 # Get version constant
-VERSION := ${shell git describe --abbrev=0 --tags}
+VERSION := $(shell git describe --abbrev=0 --tags)
 BUILD := $(shell git rev-parse HEAD)
 
 # Use linker flags to provide version/build settings to the binary

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,6 @@ FROM golang:1.15-alpine3.12 as builder
 
 RUN apk add git build-base
 
-RUN mkdir -p /usr/src/microservice-email
 WORKDIR /usr/src/microservice-email
 
 ADD .git ./.git
@@ -31,7 +30,7 @@ LABEL Author="Sergio Andres Virviescas Santana <developersavsgio@gmail.com>"
 COPY --from=builder /usr/src/microservice-email/ /microservice-email
 
 RUN cd /microservice-email \
-    && apk add make git \
+    && apk add --no-cache make git \
     && make install \
     && rm -rf /microservice-email \
     && apk del make git

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,7 +17,7 @@ func New(port int) *Api {
 
 	api := &Api{
 		server: atreugo.New(atreugo.Config{
-			Addr:             "0.0.0.0" + strconv.Itoa(port),
+			Addr:             "0.0.0.0:" + strconv.Itoa(port),
 			GracefulShutdown: true,
 		}),
 	}


### PR DESCRIPTION
Hi savsgio:
1. VERSION shouldn't be constant
2. if WORKDIR doesn't exist, it will create auto, so there is no need to leave `RUN mkdir -p /usr/src/microservice-email`
3. `apk add --no-cache make git`  with `--no-cache`,  this tells server don't  save index file, this make image smaller
```sh
~/go/src/github.com/brownchow/microservice-email(master) » docker images                                                                                                                                                                      
REPOSITORY                               TAG                     IMAGE ID       CREATED             SIZE
savsgio/microservice-email               v0.2                    e282adb2933f   About an hour ago   21.8MB
savsgio/microservice-email               latest                  e2024421f65c   2 hours ago         20MB
```
4. we should add colon before port